### PR TITLE
Fix V3008

### DIFF
--- a/Editor/UIEditor/UISceneGrid.cs
+++ b/Editor/UIEditor/UISceneGrid.cs
@@ -10,7 +10,7 @@ namespace DeltaEngine.Editor.UIEditor
 		public UISceneGrid(UIEditorScene uiEditorScene)
 		{
 			GridHeight = 30;
-			GridHeight = 30;
+			GridWidth = 30;
 			this.uiEditorScene = uiEditorScene;
 			DrawGrid();
 		}


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

-  The 'GridHeight' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 13, 12. DeltaEngine.Editor.UIEditor UISceneGrid.cs 13