### PR TITLE
Fix V3076

### DIFF
--- a/Physics3D/PhysicalEntity3D.cs
+++ b/Physics3D/PhysicalEntity3D.cs
@@ -57,7 +57,7 @@ namespace DeltaEngine.Physics3D
 			Velocity = PhysicsBody.LinearVelocity;
 			RotationAxis = PhysicsBody.AngularVelocity;
 			Orientation = PhysicsBody.GetOrientation();
-			if (Orientation.X == float.NaN)
+			if (float.IsNaN(Orientation.X))
 				throw new PhysicsBodyOrientationIsBrokenMakeSureAllValuesAreSet(PhysicsBody);
 		}
 


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

- Comparison of 'Orientation.X' with 'float.NaN' is meaningless. Use 'float.IsNaN()' method instead. DeltaEngine.Physics3D PhysicalEntity3D.cs 60