### PR TITLE
Fix V3118

### DIFF
--- a/Editor/ContentManager/Tests/ContentMetaDataCreatorTests.cs
+++ b/Editor/ContentManager/Tests/ContentMetaDataCreatorTests.cs
@@ -18,7 +18,7 @@ namespace DeltaEngine.Editor.ContentManager.Tests
 			var metaData = creator.CreateMetaDataFromFile(filePath);
 			Assert.AreEqual("DeltaEngineLogo", metaData.Name);
 			Assert.AreEqual(ContentType.Image, metaData.Type);
-			Assert.LessOrEqual((DateTime.Now - metaData.LastTimeUpdated).Seconds, 1);
+			Assert.LessOrEqual((DateTime.Now - metaData.LastTimeUpdated).TotalSeconds, 1);
 			Assert.AreEqual("en", metaData.Language);
 			Assert.AreEqual("DeltaEngineLogo.png", metaData.LocalFilePath);
 			Assert.AreEqual(0, metaData.PlatformFileId);
@@ -36,7 +36,7 @@ namespace DeltaEngine.Editor.ContentManager.Tests
 			var metaData = creator.CreateMetaDataFromFile(filePath);
 			Assert.AreEqual("Verdana12", metaData.Name);
 			Assert.AreEqual(ContentType.Xml, metaData.Type);
-			Assert.LessOrEqual((DateTime.Now - metaData.LastTimeUpdated).Seconds, 1);
+			Assert.LessOrEqual((DateTime.Now - metaData.LastTimeUpdated).TotalSeconds, 1);
 			Assert.AreEqual("en", metaData.Language);
 			Assert.AreEqual("Verdana12.xml", metaData.LocalFilePath);
 			Assert.AreEqual(0, metaData.PlatformFileId);


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Seconds component of TimeSpan is used, which does not represent full time interval. Possibly 'TotalSeconds' value was intended instead. DeltaEngine.Editor.ContentManager.Tests ContentMetaDataCreatorTests.cs 21

- Seconds component of TimeSpan is used, which does not represent full time interval. Possibly 'TotalSeconds' value was intended instead. DeltaEngine.Editor.ContentManager.Tests ContentMetaDataCreatorTests.cs 39